### PR TITLE
Decoupled image and camera_info messages #5

### DIFF
--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
@@ -58,7 +58,7 @@ namespace depthimage_to_laserscan
     /**
      * Callback for image_transport
      * 
-     * Synchronized callback for depth image and camera info.  Publishes laserscan at the end of this callback.
+     * Callback for depth image.  Publishes laserscan at the end of this callback.
      * 
      * @param depth_msg Image provided by image_transport.
      * 
@@ -92,15 +92,13 @@ namespace depthimage_to_laserscan
      */
     void reconfigureCb(depthimage_to_laserscan::DepthConfig& config, uint32_t level);
     
-    void onCameraData(const sensor_msgs::CameraInfoConstPtr& info_msg);
-
     ros::NodeHandle pnh_; ///< Private nodehandle used to generate the transport hints in the connectCb.
     image_transport::ImageTransport it_; ///< Subscribes to synchronized Image CameraInfo pairs.
     image_transport::Subscriber sub_; ///< Subscriber for image_transport
     ros::Publisher pub_; ///< Publisher for output LaserScan messages
     dynamic_reconfigure::Server<depthimage_to_laserscan::DepthConfig> srv_; ///< Dynamic reconfigure server
 
-    sensor_msgs::CameraInfoConstPtr camera_info_;
+    sensor_msgs::CameraInfoConstPtr camera_info_; ///< CameraInfo message
 
     depthimage_to_laserscan::DepthImageToLaserScan dtl_; ///< Instance of the DepthImageToLaserScan conversion class.
     

--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
@@ -37,6 +37,7 @@
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/LaserScan.h>
 #include <boost/thread/mutex.hpp>
 #include <dynamic_reconfigure/server.h>
@@ -63,8 +64,7 @@ namespace depthimage_to_laserscan
      * @param info_msg CameraInfo provided by image_transport.
      * 
      */
-    void depthCb(const sensor_msgs::ImageConstPtr& depth_msg,
-		  const sensor_msgs::CameraInfoConstPtr& info_msg);
+    void depthCb(const sensor_msgs::ImageConstPtr& depth_msg);
 
     /**
      * Callback that is called when there is a new subscriber.
@@ -93,12 +93,15 @@ namespace depthimage_to_laserscan
      */
     void reconfigureCb(depthimage_to_laserscan::DepthConfig& config, uint32_t level);
     
+    void onCameraData(const sensor_msgs::CameraInfoConstPtr& info_msg);
+
     ros::NodeHandle pnh_; ///< Private nodehandle used to generate the transport hints in the connectCb.
     image_transport::ImageTransport it_; ///< Subscribes to synchronized Image CameraInfo pairs.
-    image_transport::CameraSubscriber sub_; ///< Subscriber for image_transport
+    image_transport::Subscriber sub_; ///< Subscriber for image_transport
     ros::Publisher pub_; ///< Publisher for output LaserScan messages
     dynamic_reconfigure::Server<depthimage_to_laserscan::DepthConfig> srv_; ///< Dynamic reconfigure server
-    
+    ros::Subscriber camera_info_sub_;
+    sensor_msgs::CameraInfo camera_info_;
     depthimage_to_laserscan::DepthImageToLaserScan dtl_; ///< Instance of the DepthImageToLaserScan conversion class.
     
     boost::mutex connect_mutex_; ///< Prevents the connectCb and disconnectCb from being called until everything is initialized.

--- a/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
+++ b/include/depthimage_to_laserscan/DepthImageToLaserScanROS.h
@@ -61,7 +61,6 @@ namespace depthimage_to_laserscan
      * Synchronized callback for depth image and camera info.  Publishes laserscan at the end of this callback.
      * 
      * @param depth_msg Image provided by image_transport.
-     * @param info_msg CameraInfo provided by image_transport.
      * 
      */
     void depthCb(const sensor_msgs::ImageConstPtr& depth_msg);
@@ -100,8 +99,9 @@ namespace depthimage_to_laserscan
     image_transport::Subscriber sub_; ///< Subscriber for image_transport
     ros::Publisher pub_; ///< Publisher for output LaserScan messages
     dynamic_reconfigure::Server<depthimage_to_laserscan::DepthConfig> srv_; ///< Dynamic reconfigure server
-    ros::Subscriber camera_info_sub_;
-    sensor_msgs::CameraInfo camera_info_;
+
+    sensor_msgs::CameraInfoConstPtr camera_info_;
+
     depthimage_to_laserscan::DepthImageToLaserScan dtl_; ///< Instance of the DepthImageToLaserScan conversion class.
     
     boost::mutex connect_mutex_; ///< Prevents the connectCb and disconnectCb from being called until everything is initialized.

--- a/src/DepthImageToLaserScanROS.cpp
+++ b/src/DepthImageToLaserScanROS.cpp
@@ -57,6 +57,7 @@ DepthImageToLaserScanROS::~DepthImageToLaserScanROS(){
 void DepthImageToLaserScanROS::depthCb(const sensor_msgs::ImageConstPtr& depth_msg){
   try
   {
+    // if camera_info hasn't received, fetch the camera_info again
     if(camera_info_ == NULL)
     {
       ROS_ERROR("depthimage_to_laserscan node hasn't received camera_info.");

--- a/src/DepthImageToLaserScanROS.cpp
+++ b/src/DepthImageToLaserScanROS.cpp
@@ -44,7 +44,7 @@ DepthImageToLaserScanROS::DepthImageToLaserScanROS(ros::NodeHandle& n, ros::Node
   srv_.setCallback(f);
  
   // Subscribe the camera info once and store it
-  camera_info_  = ros::topic::waitForMessage<sensor_msgs::CameraInfo>("camera_info", n, ros::Duration(20));
+  camera_info_  = ros::topic::waitForMessage<sensor_msgs::CameraInfo>("camera_info", n);
 
   // Lazy subscription to depth image topic
   pub_ = n.advertise<sensor_msgs::LaserScan>("scan", 10, boost::bind(&DepthImageToLaserScanROS::connectCb, this, _1), boost::bind(&DepthImageToLaserScanROS::disconnectCb, this, _1));
@@ -60,8 +60,7 @@ void DepthImageToLaserScanROS::depthCb(const sensor_msgs::ImageConstPtr& depth_m
     // if camera_info hasn't received, fetch the camera_info again
     if(camera_info_ == NULL)
     {
-      ROS_ERROR("depthimage_to_laserscan node hasn't received camera_info.");
-      camera_info_ = ros::topic::waitForMessage<sensor_msgs::CameraInfo>("camera_info", ros::Duration(1));
+      ROS_ERROR("depthimage_to_laserscan node hasn't received camera_info. Will keep trying");
       return ;
     }
     sensor_msgs::LaserScanPtr scan_msg = dtl_.convert_msg(depth_msg, camera_info_);


### PR DESCRIPTION
- Switch image_transport::CameraSubscriber to image_transport::Subscriber
- Subscribe to CameraInfo only once and store the info 